### PR TITLE
Configurable driver properties when creating dataSource

### DIFF
--- a/src/main/java/org/apache/ibatis/migration/commands/BaseCommand.java
+++ b/src/main/java/org/apache/ibatis/migration/commands/BaseCommand.java
@@ -310,6 +310,7 @@ public abstract class BaseCommand implements Command {
     try {
       UnpooledDataSource dataSource = new UnpooledDataSource(getDriverClassLoader(), environment().getDriver(),
           environment().getUrl(), environment().getUsername(), environment().getPassword());
+      dataSource.setDriverProperties(environment.getVariables());
       return dataSource.getConnection();
     } catch (Exception e) {
       throw new MigrationException("Error creating ScriptRunner.  Cause: " + e, e);


### PR DESCRIPTION
Even though the properties file template has a section titled "JDBC connection properties",
it never actually passed any properties to the driver. This change just passes all properties
to the driver, and it can decide which ones it recognizes and wants to use.